### PR TITLE
feat: add Spanish translations and taxi phrases

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,1 +1,0 @@
-feat: Implement initial phrasebook UI and functionality

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Taxi Phrasebook title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/Taxi Phrasebook/i);
+  expect(headingElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,24 +9,28 @@ const phrases = {
     en: 'Please fasten your seatbelt.',
     ko: '안전벨트를 매주세요.',
     zh: '请系好安全带。',
+    es: 'Por favor, abróchese el cinturón.',
   },
-  'お支払いは現金ですか？カードですか？': {
-    en: 'Cash or card?',
-    ko: '현금으로 하시겠어요? 카드로 하시겠어요?',
-    zh: '请问您用现金还是刷卡？',
+  '料金はメーターをご確認ください': {
+    en: 'Please check the meter for the fare.',
+    ko: '요금은 미터기를 확인해 주세요.',
+    zh: '请查看计价器上的费用。',
+    es: 'Por favor, revise el taxímetro para ver la tarifa.',
   },
-  '料金はメーターの通りです。クレジットカードが利用できます': {
-    en: 'The fare is as shown on the meter. Credit cards are accepted.',
-    ko: '요금은 미터기에 표시된 대로입니다. 신용카드를 사용할 수 있습니다.',
-    zh: '车费如计价器所示。您可以使用信用卡。',
+  'クレジットカードがご利用できます': {
+    en: 'Credit cards are accepted.',
+    ko: '신용카드를 이용하실 수 있습니다.',
+    zh: '可以使用信用卡。',
+    es: 'Se aceptan tarjetas de crédito.',
   },
 };
 
-const languages = ['en', 'ko', 'zh'];
+const languages = ['en', 'ko', 'zh', 'es'];
 const languageNames: { [key: string]: string } = {
   en: 'English',
   ko: '한국어',
   zh: '中文',
+  es: 'Español',
 };
 
 


### PR DESCRIPTION
## Summary
- add Spanish option alongside English, Korean, and Chinese
- update taxi phrase set for seatbelts, meter checking, and credit card info
- adjust tests for new Taxi Phrasebook title

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689753439ffc8322994574160c81cf9a